### PR TITLE
feat: upgrade MappedQueryResultProcessor to paginate and get all records

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@aws-sdk/client-athena": "^3.696.0",
     "@aws-sdk/client-s3": "^3.717.0",
     "csv-parse": "^5.6.0",
+    "pino": "^9.6.0",
     "rxjs": "^7.8.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       csv-parse:
         specifier: ^5.6.0
         version: 5.6.0
+      pino:
+        specifier: ^9.6.0
+        version: 9.6.0
       rxjs:
         specifier: ^7.8.1
         version: 7.8.1
@@ -604,6 +607,10 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
@@ -708,6 +715,10 @@ packages:
   fast-glob@3.3.2:
     resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
     engines: {node: '>=8.6.0'}
+
+  fast-redact@3.5.0:
+    resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
+    engines: {node: '>=6'}
 
   fast-xml-parser@4.4.1:
     resolution: {integrity: sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==}
@@ -846,6 +857,10 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   os-tmpdir@1.0.2:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
@@ -908,17 +923,37 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
+  pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
+  pino-std-serializers@7.0.0:
+    resolution: {integrity: sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==}
+
+  pino@9.6.0:
+    resolution: {integrity: sha512-i85pKRCt4qMjZ1+L7sy2Ag4t1atFcdbEt76+7iRJn1g2BvsnRMGu9p8pivl9fs63M2kF/A0OacFZhTub+m/qMg==}
+    hasBin: true
+
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  process-warning@4.0.1:
+    resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
 
   regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
@@ -940,6 +975,10 @@ packages:
 
   rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
+
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -969,8 +1008,15 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  sonic-boom@4.2.0:
+    resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
+
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -1008,6 +1054,9 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  thread-stream@3.1.0:
+    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
   tmp@0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
@@ -2226,6 +2275,8 @@ snapshots:
 
   array-union@2.1.0: {}
 
+  atomic-sleep@1.0.0: {}
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
@@ -2324,6 +2375,8 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
+
+  fast-redact@3.5.0: {}
 
   fast-xml-parser@4.4.1:
     dependencies:
@@ -2457,6 +2510,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  on-exit-leak-free@2.1.2: {}
+
   os-tmpdir@1.0.2: {}
 
   outdent@0.5.0: {}
@@ -2499,9 +2554,33 @@ snapshots:
 
   pify@4.0.1: {}
 
+  pino-abstract-transport@2.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.0.0: {}
+
+  pino@9.6.0:
+    dependencies:
+      atomic-sleep: 1.0.0
+      fast-redact: 3.5.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.0.0
+      process-warning: 4.0.1
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.0
+      thread-stream: 3.1.0
+
   prettier@2.8.8: {}
 
+  process-warning@4.0.1: {}
+
   queue-microtask@1.2.3: {}
+
+  quick-format-unescaped@4.0.4: {}
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -2509,6 +2588,8 @@ snapshots:
       js-yaml: 3.14.1
       pify: 4.0.1
       strip-bom: 3.0.0
+
+  real-require@0.2.0: {}
 
   regenerator-runtime@0.14.1: {}
 
@@ -2525,6 +2606,8 @@ snapshots:
   rxjs@7.8.1:
     dependencies:
       tslib: 2.8.1
+
+  safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
 
@@ -2544,10 +2627,16 @@ snapshots:
 
   slash@3.0.0: {}
 
+  sonic-boom@4.2.0:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   spawndamnit@3.0.1:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  split2@4.2.0: {}
 
   sprintf-js@1.0.3: {}
 
@@ -2583,6 +2672,10 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  thread-stream@3.1.0:
+    dependencies:
+      real-require: 0.2.0
 
   tmp@0.0.33:
     dependencies:

--- a/src/query-results-processor.ts
+++ b/src/query-results-processor.ts
@@ -1,35 +1,61 @@
-import type { Readable } from 'node:stream'
-import { finished } from 'node:stream/promises'
+import type { Readable } from "node:stream";
+import { finished } from "node:stream/promises";
 import {
   GetQueryResultsCommand,
   type ResultSet,
   type Row,
-} from '@aws-sdk/client-athena'
-import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3'
-import { parse } from 'csv-parse'
+} from "@aws-sdk/client-athena";
+import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { parse } from "csv-parse";
+import {
+  EMPTY,
+  type Observable,
+  defer,
+  firstValueFrom,
+  from,
+  of,
+  throwError,
+  timer,
+} from "rxjs";
 import {
   MAX_BATCH_SIZE,
   type MappedQueryResultProcessorParams,
   type QueryResultProcessor,
   type S3QueryResultProcessorParams,
-} from './types.js'
+} from "./types.js";
+
+import {
+  catchError,
+  concatWith,
+  expand,
+  filter,
+  switchMap,
+} from "rxjs/operators";
+
+function validateBatchSize(maxBatchSize: number, batchSize?: number): number {
+  if (!batchSize) return maxBatchSize;
+  if (batchSize > maxBatchSize) {
+    throw new Error(`Batch size cannot be greater than ${maxBatchSize}`);
+  }
+  return batchSize;
+}
 
 /**
  * Processes Athena query results stored in S3
  */
 export class S3QueryResultProcessor implements QueryResultProcessor {
-  readonly #batchSize = MAX_BATCH_SIZE
-  readonly #s3Client: S3Client
-  readonly #s3OutputLocation: string
+  readonly #batchSize = MAX_BATCH_SIZE;
+  readonly #s3Client: S3Client;
+  readonly #s3OutputLocation: string;
 
   /**
    * Creates a new S3QueryResultProcessor
    * @param {S3QueryResultProcessorParams} config - Configuration parameters
    */
   constructor(private readonly config: S3QueryResultProcessorParams) {
-    this.#batchSize = this.#validateBatchSize(config.batchSize)
-    this.#s3OutputLocation = config.s3OutputLocation
-    this.#s3Client = new S3Client({ region: config.s3Region })
+    this.#batchSize = this.#validateBatchSize(config.batchSize);
+    this.#s3OutputLocation = config.s3OutputLocation;
+    this.#s3Client = new S3Client({ region: config.s3Region });
   }
 
   /**
@@ -39,12 +65,12 @@ export class S3QueryResultProcessor implements QueryResultProcessor {
    */
   async processResults(queryExecutionId: string): Promise<void> {
     // Get the S3 location of results
-    const s3Location = `${this.#s3OutputLocation}/${queryExecutionId}.csv`
-    const { Bucket, Key } = this.#parseS3Url(s3Location)
-    console.log('Fetching query results from S3:', s3Location)
+    const s3Location = `${this.#s3OutputLocation}/${queryExecutionId}.csv`;
+    const { Bucket, Key } = this.#parseS3Url(s3Location);
+    console.log("Fetching query results from S3:", s3Location);
 
-    const responseStream = await this.#fetchS3Object(Bucket, Key)
-    return this.#processStreamingResults(responseStream)
+    const responseStream = await this.#fetchS3Object(Bucket, Key);
+    return this.#processStreamingResults(responseStream);
   }
 
   /**
@@ -53,46 +79,46 @@ export class S3QueryResultProcessor implements QueryResultProcessor {
    * @returns {Promise<void>} Promise that resolves when processing is complete
    */
   async #processStreamingResults(stream: Readable): Promise<void> {
-    const batch: unknown[] = []
-    let totalProcessed = 0
+    const batch: unknown[] = [];
+    let totalProcessed = 0;
 
     const parser = stream.pipe(
-      parse({ columns: true, ...(this.config.csvParseOptions ?? {}) }),
-    )
+      parse({ columns: true, ...(this.config.csvParseOptions ?? {}) })
+    );
 
     try {
-      parser.on('readable', async () => {
-        let record = parser.read()
+      parser.on("readable", async () => {
+        let record = parser.read();
         while (record !== null) {
           // Work with each record
-          batch.push(record)
+          batch.push(record);
           if (batch.length >= this.#batchSize) {
-            console.log(`Processing batch of ${batch.length} records...`)
-            await this.#processBatch(batch)
-            totalProcessed += batch.length
-            batch.length = 0 // Clear array efficiently
-            console.log(`Total records processed: ${totalProcessed}`)
+            console.log(`Processing batch of ${batch.length} records...`);
+            await this.#processBatch(batch);
+            totalProcessed += batch.length;
+            batch.length = 0; // Clear array efficiently
+            console.log(`Total records processed: ${totalProcessed}`);
           }
-          record = parser.read()
+          record = parser.read();
         }
-      })
+      });
 
       // Wait for parsing to complete
-      await finished(parser)
+      await finished(parser);
       // Process remaining records
       if (batch.length > 0) {
-        console.log(`Processing final batch of ${batch.length} records...`)
-        await this.#processBatch(batch)
-        totalProcessed += batch.length
-        console.log(`Final total records processed: ${totalProcessed}`)
+        console.log(`Processing final batch of ${batch.length} records...`);
+        await this.#processBatch(batch);
+        totalProcessed += batch.length;
+        console.log(`Final total records processed: ${totalProcessed}`);
       }
-      await this.config?.onComplete?.()
+      await this.config?.onComplete?.();
     } catch (error) {
       throw new Error(
         `Error processing results: ${
-          error instanceof Error ? error.message : 'Unknown error'
-        }`,
-      )
+          error instanceof Error ? error.message : "Unknown error"
+        }`
+      );
     }
   }
 
@@ -103,13 +129,13 @@ export class S3QueryResultProcessor implements QueryResultProcessor {
    */
   async #processBatch(batch: unknown[]): Promise<void> {
     try {
-      await this.config.onData(batch)
+      await this.config.onData(batch);
     } catch (error) {
       throw new Error(
         `Error processing batch: ${
-          error instanceof Error ? error.message : 'Unknown error'
-        }`,
-      )
+          error instanceof Error ? error.message : "Unknown error"
+        }`
+      );
     }
   }
 
@@ -120,11 +146,7 @@ export class S3QueryResultProcessor implements QueryResultProcessor {
    * @throws {Error} If batch size exceeds maximum allowed
    */
   #validateBatchSize(batchSize?: number): number {
-    if (!batchSize) return MAX_BATCH_SIZE
-    if (batchSize > MAX_BATCH_SIZE) {
-      throw new Error(`Batch size cannot be greater than ${MAX_BATCH_SIZE}`)
-    }
-    return batchSize
+    return validateBatchSize(this.#batchSize, batchSize);
   }
 
   /**
@@ -136,15 +158,15 @@ export class S3QueryResultProcessor implements QueryResultProcessor {
    */
   async #fetchS3Object(Bucket: string, Key: string): Promise<Readable> {
     const response = await this.#s3Client.send(
-      new GetObjectCommand({ Bucket, Key }),
-    )
+      new GetObjectCommand({ Bucket, Key })
+    );
 
     if (!response.Body) {
-      throw new Error(`Failed to fetch file: ${Bucket}/${Key}`)
+      throw new Error(`Failed to fetch file: ${Bucket}/${Key}`);
     }
-    console.log('S3 response metadata:', response.$metadata)
+    console.log("S3 response metadata:", response.$metadata);
 
-    return response.Body as Readable
+    return response.Body as Readable;
   }
 
   /**
@@ -155,23 +177,23 @@ export class S3QueryResultProcessor implements QueryResultProcessor {
    */
   #parseS3Url(url: string): { Bucket: string; Key: string } {
     try {
-      const parsedUrl = new URL(url)
-      const bucket = parsedUrl.hostname.split('.')[0]
+      const parsedUrl = new URL(url);
+      const bucket = parsedUrl.hostname.split(".")[0];
 
       if (!bucket) {
-        throw new Error('Invalid S3 URL: missing bucket name')
+        throw new Error("Invalid S3 URL: missing bucket name");
       }
 
       return {
         Bucket: bucket,
         Key: parsedUrl.pathname.slice(1),
-      }
+      };
     } catch (error) {
       throw new Error(
         `Invalid S3 URL: ${
-          error instanceof Error ? error.message : 'Unknown error'
-        }`,
-      )
+          error instanceof Error ? error.message : "Unknown error"
+        }`
+      );
     }
   }
 }
@@ -180,11 +202,17 @@ export class S3QueryResultProcessor implements QueryResultProcessor {
  * Processes Athena query results by mapping them to objects
  */
 export class MappedQueryResultProcessor implements QueryResultProcessor {
+  readonly #batchSize = MAX_BATCH_SIZE;
+  readonly #shouldPaginate: boolean = true;
+
   /**
    * Creates a new MappedQueryResultProcessor
    * @param {MappedQueryResultProcessorParams} config - Configuration parameters
    */
-  constructor(private readonly config: MappedQueryResultProcessorParams) {}
+  constructor(private readonly config: MappedQueryResultProcessorParams) {
+    this.#batchSize = this.#validateBatchSize(config.MaxResults);
+    this.#shouldPaginate = config.paginateResults ?? true;
+  }
 
   /**
    * Processes query results by mapping them to objects
@@ -192,38 +220,94 @@ export class MappedQueryResultProcessor implements QueryResultProcessor {
    * @returns {Promise<Record<string, string>[]>} Promise resolving to array of mapped objects
    */
   async processResults(
-    queryExecutionId: string,
+    queryExecutionId: string
   ): Promise<Record<string, string>[]> {
-    console.log('Fetching results for QueryExecutionId:', queryExecutionId)
+    console.log("Fetching results for QueryExecutionId:", queryExecutionId);
 
     try {
-      const resultSet = await this.#fetchQueryResults(queryExecutionId)
-      return this.#extractRows(resultSet)
+      const resultSets = await firstValueFrom(
+        this.#fetchQueryResults(queryExecutionId, undefined)
+      );
+      return resultSets.flatMap((resultSet) => this.#extractRows(resultSet));
     } catch (error) {
       throw new Error(
         `Error processing results: ${
-          error instanceof Error ? error.message : 'Unknown error'
-        }`,
-      )
+          error instanceof Error ? error.message : "Unknown error"
+        }`
+      );
     }
   }
 
   /**
    * Fetches query results from Athena
    * @param {string} queryExecutionId - The ID of the query execution
-   * @returns {Promise<ResultSet>} Promise resolving to Athena ResultSet
-   * @throws {Error} If results are empty or undefined
+   * @param {string | undefined} nextToken - The pagination token
+   * @returns {Promise<ResultSet[]>} Promise resolving to Athena ResultSet
+   * @throws {Error} If results are undefined
    */
-  async #fetchQueryResults(queryExecutionId: string): Promise<ResultSet> {
-    const response = await this.config.athenaClient.send(
-      new GetQueryResultsCommand({ QueryExecutionId: queryExecutionId }),
-    )
+  #fetchQueryResults(
+    queryExecutionId: string,
+    nextToken: string | undefined
+  ): Observable<ResultSet[]> {
+    return defer(() =>
+      from(
+        this.config.athenaClient.send(
+          new GetQueryResultsCommand({
+            QueryExecutionId: queryExecutionId,
+            MaxResults: this.#batchSize,
+            NextToken: nextToken,
+          })
+        )
+      )
+    ).pipe(
+      switchMap((response) => {
+        if (!response.ResultSet) {
+          return throwError(
+            () =>
+              new Error(
+                `Query results are undefined for QueryExecutionId: ${queryExecutionId}`
+              )
+          );
+        }
 
-    if (!response.ResultSet) {
-      throw new Error('Query results are empty or undefined')
-    }
+        const resultObservable = of(response.ResultSet);
 
-    return response.ResultSet
+        if (this.#shouldPaginate && response.NextToken) {
+          console.log("Fetching next page of results...");
+          return resultObservable.pipe(
+            concatWith(of(response.NextToken)) // Pass the NextToken for pagination
+          );
+        }
+
+        console.log("Query results fetching complete");
+        return resultObservable; // Only emit the current ResultSet
+      }),
+      expand(
+        (resultOrNextToken) =>
+          typeof resultOrNextToken === "string" // If it's a NextToken, fetch the next page
+            ? timer(500).pipe(
+                switchMap(() =>
+                  this.#fetchQueryResults(queryExecutionId, resultOrNextToken)
+                )
+              )
+            : EMPTY // If it's a ResultSet, stop recursion
+      ),
+      filter(
+        (resultOrNextToken) => typeof resultOrNextToken !== "string" // Keep only ResultSet objects
+      ),
+      catchError((error) => {
+        console.error(
+          `Error fetching query results for QueryExecutionId: ${queryExecutionId}`,
+          error
+        );
+        return throwError(
+          () =>
+            new Error(
+              `Failed to fetch query results for QueryExecutionId: ${queryExecutionId}. ${error.message}`
+            )
+        );
+      })
+    );
   }
 
   /**
@@ -233,13 +317,13 @@ export class MappedQueryResultProcessor implements QueryResultProcessor {
    * @throws {Error} If no headers are found
    */
   #extractHeaders(rows: Row[]): string[] {
-    const headers = rows[0]?.Data?.map((column) => column.VarCharValue || '')
+    const headers = rows[0]?.Data?.map((column) => column.VarCharValue || "");
 
     if (!headers || headers.length === 0) {
-      throw new Error('No headers found in the result set')
+      throw new Error("No headers found in the result set");
     }
 
-    return headers
+    return headers;
   }
 
   /**
@@ -249,16 +333,16 @@ export class MappedQueryResultProcessor implements QueryResultProcessor {
    * @returns {Record<string, string>} Object with header-value pairs
    */
   #mapRowToObject(row: Row, headers: string[]): Record<string, string> {
-    const mappedRow: Record<string, string> = {}
+    const mappedRow: Record<string, string> = {};
 
     row.Data?.forEach((value, index) => {
-      const header = headers[index]
+      const header = headers[index];
       if (header) {
-        mappedRow[header] = value.VarCharValue || ''
+        mappedRow[header] = value.VarCharValue || "";
       }
-    })
+    });
 
-    return mappedRow
+    return mappedRow;
   }
 
   /**
@@ -270,15 +354,25 @@ export class MappedQueryResultProcessor implements QueryResultProcessor {
    * @throws {Error} If no headers are found
    */
   #extractRows(resultSet: ResultSet): Record<string, string>[] {
-    const { Rows } = resultSet
+    const { Rows } = resultSet;
     if (!Rows || Rows.length === 0) {
-      console.error('No rows found in result set')
-      return []
+      console.error("No rows found in result set");
+      return [];
     }
-    const headers = this.#extractHeaders(Rows)
+    const headers = this.#extractHeaders(Rows);
     if (!headers.length) {
-      throw new Error('No headers found in the result set')
+      throw new Error("No headers found in the result set");
     }
-    return Rows.slice(1).map((row) => this.#mapRowToObject(row, headers))
+    return Rows.slice(1).map((row) => this.#mapRowToObject(row, headers));
+  }
+
+  /**
+   * Validates the batch size configuration
+   * @param {number} [batchSize] - The batch size to validate
+   * @returns {number} The validated batch size
+   * @throws {Error} If batch size exceeds maximum allowed
+   */
+  #validateBatchSize(batchSize?: number): number {
+    return validateBatchSize(this.#batchSize, batchSize);
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,7 @@ export interface S3QueryResultProcessorParams {
   onComplete?: (data?: unknown) => Promise<void>
   /**
    * Optional: The maximum number of records to process in a single batch
+   * should be less than or equal to 999
    * @default 999
    */
   batchSize?: number
@@ -71,9 +72,22 @@ export interface S3QueryResultProcessorParams {
 
 export interface MappedQueryResultProcessorParams {
   /**
-   *
+   * Athena client for executing queries
    */
   athenaClient: AthenaClient
+
+  /**
+   * Optional: Maximum number of records per query
+   * should be less than or equal to 999
+   * @default 999
+   */
+  MaxResults?: number
+
+  /**
+   * Should results be paginated. Athena has a limit of 1000 records per query, so this is useful for large datasets
+   * @default true
+   */
+  paginateResults?: boolean
 }
 
 /**


### PR DESCRIPTION
Scope — `MappedQueryResultProcessor`

- Add option to paginate results
- Add option to decide number of records to fetch per query
- Add a delay of 500ms in between each paginated request